### PR TITLE
#2 and #3

### DIFF
--- a/BuckarooSdk/DataTypes/RequestBases/TransactionSpecificationBase.cs
+++ b/BuckarooSdk/DataTypes/RequestBases/TransactionSpecificationBase.cs
@@ -8,7 +8,7 @@ namespace BuckarooSdk.DataTypes.RequestBases
 {
 	public class TransactionSpecificationBase : IRequestBase
 	{
-		internal List<SpecificationRequestedService> Services { get; set; }
+		public List<SpecificationRequestedService> Services { get; set; }
 
 		public TransactionSpecificationBase()
 		{

--- a/BuckarooSdk/DataTypes/RequestBases/TransactionSpecificationBase.cs
+++ b/BuckarooSdk/DataTypes/RequestBases/TransactionSpecificationBase.cs
@@ -15,7 +15,7 @@ namespace BuckarooSdk.DataTypes.RequestBases
 			this.Services = new List<SpecificationRequestedService>();
 		}
 
-		public TransactionSpecificationBase AddService(string service, int version = 1)
+		public TransactionSpecificationBase AddService(string service, int? version = null)
 		{
 			var serviceToBeAdded = new SpecificationRequestedService()
 			{

--- a/BuckarooSdk/DataTypes/SpecificationRequestedService.cs
+++ b/BuckarooSdk/DataTypes/SpecificationRequestedService.cs
@@ -9,6 +9,6 @@ namespace BuckarooSdk.DataTypes
 	public class SpecificationRequestedService
 	{
 		public string Name { get; set; }
-		public int Version { get; set; }
+		public int? Version { get; set; }
 	}
 }


### PR DESCRIPTION
Issue #2 I was able to resolve by simply exposing the internal `Services` property so it can be serialized in the `SendRequest` method.

For issue #3, however, perhaps some backend evaluation is required. This change would at least expose the desired information to the SDK users, but will make the multiple services call heavier when users omit the version.