### PR TITLE
bugfix/PS2-1259: .NET SDK - Handle push with empty Service

### DIFF
--- a/BuckarooSdk.Tests/Services/Ideal/IdealTests.cs
+++ b/BuckarooSdk.Tests/Services/Ideal/IdealTests.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.Net;
 using System.Net.Http;
 using System.Text;
 
@@ -205,10 +206,11 @@ namespace BuckarooSdk.Tests.Services.Ideal
                 var requestTimeStamp = Convert.ToUInt64(timeSpan.TotalSeconds).ToString();
                 // create random nonce for each request
 
+                var requestUriEncoded = WebUtility.UrlEncode(TestSettings.PushUri)?.ToLower();
 
                 var pushSignature = this.BuckarooClient.GetSignatureCalculationService().CalculateSignature(bodyAsBytes, HttpMethod.Post.ToString(),
                     requestTimeStamp, Guid.NewGuid().ToString("N"),
-                    TestSettings.PushUri, TestSettings.WebsiteKey, TestSettings.SecretKey);
+                    requestUriEncoded, TestSettings.WebsiteKey, TestSettings.SecretKey);
 
 
                 var authorizationheader = $"hmac {pushSignature}";              // DEZE IS BELANGRIJK: SIGNATURE
@@ -224,9 +226,9 @@ namespace BuckarooSdk.Tests.Services.Ideal
                 var transactionKey = push.Key;
                 var transactionStatus = push.Status;
 
-                var iban = responseData.ConsumerIban;
-                var bic = responseData.ConsumerBic;
-                var consumerName = responseData.ConsumerName;
+                var iban = responseData?.ConsumerIban;
+                var bic = responseData?.ConsumerBic;
+                var consumerName = responseData?.ConsumerName;
 
                 // The following KeyValuePair can be used to update your transaction
                 var newTransactionStatus = new KeyValuePair<string, int>(transactionKey, transactionStatus.Code.Code);

--- a/BuckarooSdk/DataTypes/Push/Push.cs
+++ b/BuckarooSdk/DataTypes/Push/Push.cs
@@ -7,38 +7,41 @@ using static BuckarooSdk.Constants.Services;
 
 namespace BuckarooSdk.DataTypes.Push
 {
-	public abstract class Push
-	{
-		/// <summary>
-		/// The transaction key
-		/// </summary>
-		public string Key { get; set; }
-		/// <summary>
-		/// The status of the transaction
-		/// </summary>
-		public Status Status { get; set; }
-		/// <summary>
-		/// The list of services that were available for the transaction request
-		/// </summary>
-		public List<Response.Service> Services { get; set; }
+    public abstract class Push
+    {
+        /// <summary>
+        /// The transaction key
+        /// </summary>
+        public string Key { get; set; }
+        /// <summary>
+        /// The status of the transaction
+        /// </summary>
+        public Status Status { get; set; }
+        /// <summary>
+        /// The list of services that were available for the transaction request
+        /// </summary>
+        public List<Response.Service> Services { get; set; }
 
-		public List<ServiceNames> GetServices()
-		{
-			return this.Services.Select(service => (ServiceNames) Enum.Parse(typeof(ServiceNames), service.Name, true)).ToList();
-		}
+        public List<ServiceNames> GetServices()
+        {
+            return this.Services?.Select(service => (ServiceNames)Enum.Parse(typeof(ServiceNames), service.Name, true)).ToList();
+        }
 
-		// abstract class Response
-		public T GetActionResponse<T>()
-			where T : ActionPush, new()
-		{
-			var result = new T();
+        // abstract class Response
+        public T GetActionResponse<T>()
+            where T : ActionPush, new()
+        {
+            var result = new T();
 
-			var service = this.Services.FirstOrDefault(s => s.Name.Equals(result.ServiceNames.ToString(), StringComparison.OrdinalIgnoreCase));
-			if (service == null) return null;
+            if (this.Services == null)
+                return null;
 
-			result.FillFromPush(service);
+            var service = this.Services.FirstOrDefault(s => s.Name.Equals(result.ServiceNames.ToString(), StringComparison.OrdinalIgnoreCase));
+            if (service == null) return null;
 
-			return result;
-		}
-	}
+            result.FillFromPush(service);
+
+            return result;
+        }
+    }
 }


### PR DESCRIPTION
We've had a request from one of our Merchants to handle a null reference in push notification service. This was being held by adding some null checks on code also the Unit Tests were fixed so we can check how to implement this feature.