### PR TITLE
Add NuGet publishing via trusted publishing (OIDC)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  # Keep the GitHub Actions used in workflows current (and, once SHA-pinned,
+  # Dependabot will bump the pins for you).
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,8 +74,10 @@ jobs:
           user: ${{ secrets.NUGET_USER }}   # nuget.org username of the policy owner account
 
       - name: Push to nuget.org
+        env:
+          NUGET_API_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}
         run: >
-          dotnet nuget push '${{ runner.temp }}/nupkgs/*.nupkg'
-          --api-key '${{ steps.login.outputs.NUGET_API_KEY }}'
+          dotnet nuget push "$RUNNER_TEMP/nupkgs/*.nupkg"
+          --api-key "$NUGET_API_KEY"
           --source https://api.nuget.org/v3/index.json
           --skip-duplicate

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,81 @@
+name: Publish NuGet package
+
+# Publish only when a GitHub Release is published — an explicit, auditable trigger.
+# Nothing publishes on push/PR.
+on:
+  release:
+    types: [published]
+
+# Deny-by-default at the workflow level. The publish job re-grants only what it needs.
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-nuget
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-24.04
+
+    # Binds this run to the GitHub Actions environment named "release".
+    # Put protection rules on that environment (required reviewers + tag/branch
+    # restriction) and set the SAME name in the nuget.org Trusted Publishing policy.
+    environment: release
+
+    permissions:
+      id-token: write   # required: lets THIS job mint the OIDC token for nuget.org
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false   # don't leave the git token on disk
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        with:
+          dotnet-version: '8.0.x'
+
+      # Pass the tag through the environment, never inline into the shell — a
+      # release tag is attacker-controllable and may contain shell metacharacters.
+      # Validate it as a version so only well-formed values reach later steps.
+      - name: Derive package version from the release tag
+        id: version
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          version="${TAG_NAME#v}"   # v1.5.5 -> 1.5.5
+          if ! [[ "$version" =~ ^[0-9]+(\.[0-9]+)*(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Refusing to publish: tag '$TAG_NAME' is not a valid version"
+            exit 1
+          fi
+          echo "value=$version" >> "$GITHUB_OUTPUT"
+
+      # Pack ONLY the library. BuckarooSdk.Tests is a legacy .NET Framework 4.7.1
+      # (packages.config) project and cannot restore/run on a Linux runner.
+      - name: Pack
+        env:
+          PKG_VERSION: ${{ steps.version.outputs.value }}
+        run: >
+          dotnet pack BuckarooSdk/BuckarooSdk.csproj
+          --configuration Release
+          -p:Version="$PKG_VERSION"
+          -p:ContinuousIntegrationBuild=true
+          --output "$RUNNER_TEMP/nupkgs"
+
+      # Exchange the OIDC token for a short-lived (1 hour) nuget.org API key.
+      # Do this immediately before push so the key can't expire mid-run.
+      - name: NuGet login (OIDC -> temporary API key)
+        id: login
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+        with:
+          user: ${{ secrets.NUGET_USER }}   # nuget.org username of the policy owner account
+
+      - name: Push to nuget.org
+        run: >
+          dotnet nuget push '${{ runner.temp }}/nupkgs/*.nupkg'
+          --api-key '${{ steps.login.outputs.NUGET_API_KEY }}'
+          --source https://api.nuget.org/v3/index.json
+          --skip-duplicate

--- a/BuckarooSdk/BuckarooSdk.csproj
+++ b/BuckarooSdk/BuckarooSdk.csproj
@@ -5,8 +5,22 @@
 		<RootNamespace>BuckarooSdk</RootNamespace>
 		<AssemblyName>BuckarooSdk</AssemblyName>
 		<Description>.NET Standard SDK for the Buckaroo API</Description>
+		<PackageId>BuckarooSdk</PackageId>
+		<Authors>Buckaroo</Authors>
+		<Company>Buckaroo</Company>
+		<Copyright>Copyright © Buckaroo</Copyright>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<PackageProjectUrl>https://github.com/buckaroo-it/BuckarooSdk_DotNet</PackageProjectUrl>
+		<RepositoryUrl>https://github.com/buckaroo-it/BuckarooSdk_DotNet</RepositoryUrl>
+		<RepositoryType>git</RepositoryType>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<PackageTags>buckaroo;payments;payment;psp;ideal;creditcard;sdk</PackageTags>
 		<PackageIconUrl>https://www.buckaroo.nl/assets/static/favicons/apple-touch-icon.png</PackageIconUrl>
 	</PropertyGroup>
+
+	<ItemGroup>
+		<None Include="../README.md" Pack="true" PackagePath="/" />
+	</ItemGroup>
 
 	<ItemGroup>
 		<Folder Include="DataTypes\GlobalGroups\" />

--- a/BuckarooSdk/BuckarooSdk.csproj
+++ b/BuckarooSdk/BuckarooSdk.csproj
@@ -15,7 +15,7 @@
 		<RepositoryType>git</RepositoryType>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageTags>buckaroo;payments;payment;psp;ideal;creditcard;sdk</PackageTags>
-		<PackageIconUrl>https://www.buckaroo.nl/assets/static/favicons/apple-touch-icon.png</PackageIconUrl>
+		<PackageIconUrl>https://www.buckaroo.nl/dist/assets/favicons/mkb/favicon-32x32.png?v=3</PackageIconUrl>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/README.md
+++ b/README.md
@@ -1,8 +1,205 @@
-﻿Buckaroo .NET SDK
-=============
+# Buckaroo .NET SDK
 
-Software Development Kit which can be used for easy access to the Buckaroo API.
+[![NuGet version](https://img.shields.io/nuget/v/BuckarooSdk.svg)](https://www.nuget.org/packages/BuckarooSdk/)
+[![NuGet downloads](https://img.shields.io/nuget/dt/BuckarooSdk.svg)](https://www.nuget.org/packages/BuckarooSdk/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+
+Official .NET SDK for the [Buckaroo](https://www.buckaroo.nl/) payment platform. It provides a
+strongly-typed, fluent wrapper around the Buckaroo JSON API so you can create transactions, add
+services, and handle status pushes without hand-rolling requests or signatures.
+
+## Requirements
+
+- **.NET Standard 2.0** or higher — works with .NET 6/7/8+, .NET Core 2.0+, and .NET Framework 4.6.1+.
+- A Buckaroo account with a **website key** and **secret key** from the
+  [Buckaroo Payment Plaza](https://plaza.buckaroo.nl/).
+
+The only runtime dependency is [Newtonsoft.Json](https://www.nuget.org/packages/Newtonsoft.Json/).
+
+## Installation
+
+Install the [`BuckarooSdk`](https://www.nuget.org/packages/BuckarooSdk/) package from NuGet.
+
+**.NET CLI**
+
+```bash
+dotnet add package BuckarooSdk
+```
+
+**Package Manager Console**
+
+```powershell
+Install-Package BuckarooSdk
+```
+
+**PackageReference**
+
+```xml
+<PackageReference Include="BuckarooSdk" Version="*" />
+```
+
+## Getting started
+
+### Create a client
+
+`SdkClient` is a lightweight factory — it holds no credentials. You pass your keys and choose the
+environment per request via `Authenticate(...)`, so a single client instance can be reused across
+requests and is safe to register as a singleton.
+
+```csharp
+using BuckarooSdk;
+
+var client = new SdkClient();
+```
+
+### Create a payment
+
+The API is a fluent chain: `CreateRequest → Authenticate → TransactionRequest → SetBasicFields →
+<payment method> → <action> → Execute`. Here is a minimal iDEAL payment:
+
+```csharp
+using System.Globalization;
+using BuckarooSdk;
+using BuckarooSdk.DataTypes.RequestBases;
+using BuckarooSdk.Services.Ideal.TransactionRequest;
+
+var client = new SdkClient();
+
+var response = client.CreateRequest()
+    .Authenticate(websiteKey, secretKey, isLive: false, new CultureInfo("nl-NL"))
+    .TransactionRequest()
+    .SetBasicFields(new TransactionBase
+    {
+        Currency = "EUR",
+        AmountDebit = 10.00m,
+        Invoice = "INV-0001",
+        Description = "Order 0001",
+        ReturnUrl = "https://your-shop.example/return",
+        PushUrl = "https://your-shop.example/webhooks/buckaroo",
+    })
+    .Ideal()
+    .Pay(new IdealPayRequest
+    {
+        Issuer = BuckarooSdk.Services.Ideal.Constants.Issuers.IngBank,
+    })
+    .Execute();
+```
+
+`ReturnUrl` and `PushUrl` are optional per transaction; when omitted, Buckaroo falls back to the URLs
+configured for your website key in the Payment Plaza.
+
+Other payment methods are selected the same way — `.Visa()`, `.MasterCard()`, `.Maestro()`,
+`.Bancontact()`, `.Paypal()`, and so on — each exposing method-specific actions such as `.Pay(...)`,
+`.Refund(...)`, or `.Authorize(...)`. See the [`BuckarooSdk/Services`](BuckarooSdk/Services) folder
+for the full list.
+
+### Handle the response
+
+`Execute()` returns a `RequestResponse`. Check the status code against `BuckarooSdk.Constants.Status`,
+and for redirect-based methods like iDEAL send the shopper to the URL in `RequiredAction`:
+
+```csharp
+using BuckarooSdk.Services.Ideal.TransactionRequest;
+
+if (response.Status.Code.Code == BuckarooSdk.Constants.Status.PendingProcessing)
+{
+    // Redirect the shopper to their bank to complete the payment.
+    var redirectUrl = response.RequiredAction.RedirectURL;
+}
+
+var transactionKey = response.Key;                              // reference for later lookups/pushes
+var ideal = response.GetActionResponse<IdealPayResponse>();     // typed, method-specific fields
+```
+
+Common status codes (`BuckarooSdk.Constants.Status`): `Success = 190`, `Failed = 490`,
+`Declined = 690`, `PendingInput = 790`, `PendingProcessing = 791`, `CanceledByUser = 890`.
+
+### Async
+
+Every action also has an awaitable variant — prefer it in async code. `Execute()` is just a blocking
+wrapper around `ExecuteAsync()`:
+
+```csharp
+var response = await client.CreateRequest()
+    .Authenticate(websiteKey, secretKey, isLive: false, new CultureInfo("nl-NL"))
+    .TransactionRequest()
+    .SetBasicFields(/* ... */)
+    .Ideal()
+    .Pay(/* ... */)
+    .ExecuteAsync();
+```
+
+### Handle status pushes
+
+Buckaroo confirms the final result of a transaction with a signed **push** to your `PushUrl`. Use
+the push handler to verify the signature and deserialize the payload — it throws
+`AuthenticationException` if the signature is invalid, so an unverified push never reaches your code:
+
+```csharp
+using BuckarooSdk;
+using BuckarooSdk.DataTypes.Push;
+
+var pushHandler = client.GetPushHandler(secretKey);
+
+// body: the raw request bytes; requestUri: the absolute URL Buckaroo posted to;
+// authorizationHeader: the incoming "Authorization" header value.
+Push push = pushHandler.DeserializePush(body, requestUri, authorizationHeader);
+
+if (push.Status.Code.Code == BuckarooSdk.Constants.Status.Success)
+{
+    var transactionKey = push.Key;
+    // Mark the order as paid.
+}
+```
+
+## Test vs live
+
+The environment is chosen entirely by the `isLive` argument to `Authenticate(...)`:
+
+| `isLive` | Endpoint |
+|---|---|
+| `false` | `https://testcheckout.buckaroo.nl` (test) |
+| `true`  | `https://checkout.buckaroo.nl` (production) |
+
+Use your **test** website/secret keys against the test endpoint while integrating, then switch
+`isLive` to `true` with your live keys.
+
+## Documentation
+
+- **Buckaroo developer documentation:** https://docs.buckaroo.io/
+- **API reference & supported payment methods:** https://docs.buckaroo.io/reference
+- **This package on NuGet:** https://www.nuget.org/packages/BuckarooSdk/
+
+## Development
+
+```bash
+# Restore & build the library
+dotnet build BuckarooSdk/BuckarooSdk.csproj -c Release
+
+# Pack locally (matches what CI publishes)
+dotnet pack BuckarooSdk/BuckarooSdk.csproj -c Release -p:Version=0.0.1-local -o ./artifacts
+```
+
+**Tests.** `BuckarooSdk.Tests` is a legacy .NET Framework 4.7.1 (`packages.config`) project, so it
+builds and runs on **Windows** via Visual Studio or `msbuild` + `nuget restore` — not under
+`dotnet test` on Linux/macOS. The tests read credentials from a local, git-ignored
+`TestSettings` class (via user secrets); supply your own website/secret keys to run them.
+
+Contributions are welcome — please open an issue or pull request against
+[`buckaroo-it/BuckarooSdk_DotNet`](https://github.com/buckaroo-it/BuckarooSdk_DotNet).
 
 ## Releasing
 
-Maintainers: see [RELEASING.md](RELEASING.md) for how to publish a new version to NuGet. 
+Maintainers: see [RELEASING.md](RELEASING.md) for how to publish a new version to NuGet. Releases are
+published automatically via GitHub Actions using NuGet Trusted Publishing (OIDC) — no API key to
+manage.
+
+## Support
+
+For questions about your account or the API, contact Buckaroo support at
+[support@buckaroo.nl](mailto:support@buckaroo.nl). For bugs or feature requests in this SDK, open an
+issue on [GitHub](https://github.com/buckaroo-it/BuckarooSdk_DotNet/issues).
+
+## License
+
+Released under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 ﻿Buckaroo .NET SDK
 =============
 
-Software Development Kit which can be used for easy access to the Buckaroo API. 
+Software Development Kit which can be used for easy access to the Buckaroo API.
+
+## Releasing
+
+Maintainers: see [RELEASING.md](RELEASING.md) for how to publish a new version to NuGet. 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,111 @@
+# Releasing a new version
+
+This package (`BuckarooSdk` on [nuget.org](https://www.nuget.org/packages/BuckarooSdk/)) is
+published automatically by GitHub Actions using **NuGet Trusted Publishing** (OIDC). There is
+**no API key** to manage — publishing is triggered by creating a **GitHub Release**, and the
+workflow exchanges a short-lived OIDC token for a temporary nuget.org key at publish time.
+
+The workflow is [`.github/workflows/publish.yml`](.github/workflows/publish.yml).
+
+## TL;DR
+
+1. Make sure `master` contains everything you want to ship (and builds).
+2. Create a GitHub Release with a tag like **`v1.5.5`**, targeting `master`.
+3. Approve the deployment when prompted (the `release` environment requires a reviewer).
+4. Confirm the new version appears on nuget.org a few minutes later.
+
+That's it — you never touch a NuGet API key.
+
+## How versioning works
+
+- The package version comes **entirely from the release tag** — the `.csproj` intentionally has
+  no `<Version>`.
+- Use the tag format **`vMAJOR.MINOR.PATCH`** (the leading `v` is stripped, so `v1.5.5` publishes
+  `1.5.5`). Follow [SemVer](https://semver.org/).
+- Pre-releases are supported: `v1.6.0-beta.1` → `1.6.0-beta.1` (published as a pre-release on
+  nuget.org).
+- The workflow **validates the tag** and refuses to publish if it isn't a well-formed version, so
+  a stray tag like `nightly` won't accidentally push a package.
+- Versions are immutable on nuget.org — you **cannot overwrite** an already-published version.
+  If something is wrong, bump the version and release again.
+
+## Step-by-step
+
+1. **Prepare `master`.** Merge the changes you want to release. Build/test locally first —
+   see [Local build & test](#local-build--test); the publish workflow does **not** run the tests.
+
+2. **Pick the next version.** Check the [current versions on nuget.org](https://www.nuget.org/packages/BuckarooSdk/#versions-body-tab)
+   and increment per SemVer.
+
+3. **Create the GitHub Release.**
+   - GitHub → **Releases** → **Draft a new release**.
+   - **Choose a tag** → type the new tag, e.g. `v1.5.5` → *Create new tag on publish*.
+   - **Target**: `master`.
+   - Title + release notes describing what changed.
+   - Click **Publish release**.
+
+   Or from the CLI:
+   ```bash
+   gh release create v1.5.5 --target master --title "v1.5.5" --notes "…what changed…"
+   ```
+
+4. **Approve the deployment.** Publishing the release starts the *Publish NuGet package* workflow.
+   Because it runs in the protected `release` environment, a required reviewer must approve it
+   (Actions → the running workflow → **Review deployments** → Approve). This is the intentional
+   human gate before anything hits nuget.org.
+
+5. **Verify.** Watch the workflow finish green, then check the version on
+   [nuget.org](https://www.nuget.org/packages/BuckarooSdk/). Indexing/validation usually takes a
+   few minutes.
+
+## What the workflow does
+
+On a published release it:
+
+1. Checks out the repo and installs the .NET SDK.
+2. Derives and validates the version from the release tag.
+3. Runs `dotnet pack` on **`BuckarooSdk/BuckarooSdk.csproj` only** (see note below).
+4. Logs in to nuget.org via OIDC (`NuGet/login`), receiving a temporary API key valid for 1 hour.
+5. Pushes the `.nupkg` with `--skip-duplicate`, so re-running a release that already published is
+   harmless (it won't error, but it also won't overwrite).
+
+> **Why only the library project?** `BuckarooSdk.Tests` is a legacy .NET Framework 4.7.1
+> (`packages.config`) project that can't restore or run on the Linux build agent, so the workflow
+> packs the netstandard2.0 library directly instead of the whole solution.
+
+## Local build & test
+
+```bash
+# Build/pack the library (matches what CI publishes)
+dotnet pack BuckarooSdk/BuckarooSdk.csproj -c Release -p:Version=1.5.5-local -o ./artifacts
+
+# The test project is .NET Framework 4.7.1 — build/run it on Windows with Visual Studio
+# or msbuild + nuget restore (packages.config). It does not run under `dotnet test` on Linux.
+```
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| Workflow fails at *Derive version* with "not a valid version" | The tag isn't `vX.Y.Z` (or a valid SemVer). Delete the tag/release and recreate with a proper version. |
+| Workflow doesn't start at all | It only triggers on **release: published** — a plain `git tag`/push won't do it. Create an actual GitHub Release. Also confirm the tag matches the environment's allowed tag pattern (`v*`). |
+| Push fails with 403 / policy not found | The nuget.org Trusted Publishing policy is inactive. Usually the policy-owner service account was removed from the `BuckarooBV` org, or the policy's Repository/Workflow/Environment values drifted from this workflow. Re-check the policy. |
+| "already exists" but exits green | Expected — `--skip-duplicate`. That version is already published; bump and release again. |
+| Temporary key expired | Only happens if the job stalls > 1 hour between login and push. Just re-run the job. |
+
+## One-time setup (reference)
+
+This is already configured; documented here so it can be recreated.
+
+- **nuget.org Trusted Publishing policy** (nuget.org → your account → *Trusted Publishing*):
+  - Package Owner: `BuckarooBV`
+  - Repository Owner: `buckaroo-it`
+  - Repository: `BuckarooSdk_DotNet`
+  - Workflow File: `publish.yml`
+  - Environment: `release`
+  - Owned by a **dedicated service account** that is a permanent member of the `BuckarooBV` org
+    (if the owning user leaves the org, the policy goes inactive).
+- **GitHub environment `release`** (repo → Settings → Environments): required reviewer(s) and
+  deployment restricted to tags matching `v*`.
+- **Environment secret `NUGET_USER`**: the nuget.org username (profile name, *not* email) of the
+  policy-owner account.


### PR DESCRIPTION
## What

Adds automated NuGet publishing for `BuckarooSdk` using **NuGet Trusted Publishing** (OIDC, short-lived key — no long-lived API key stored). Publishing is triggered by creating a **GitHub Release**; the package version comes from the release tag.

Also included:
- Package metadata on the `.csproj` (MIT license, README, repository URL, tags) so the nuget.org page is complete and links back to the source.
- `RELEASING.md` documenting the release flow, linked from the README.
- Dependabot for GitHub Actions to keep the pinned action SHAs current.

## Before this can publish (one-time, outside this repo)

- A nuget.org **Trusted Publishing policy** matching repo `buckaroo-it/BuckarooSdk_DotNet`, workflow `publish.yml`, environment `release`.
- A GitHub **`release` environment** with a required reviewer and deployment restricted to `v*` tags.
- A **`NUGET_USER`** secret (nuget.org username of the policy-owner account).

See `RELEASING.md` for the full setup and step-by-step.

## Security notes

- The release tag flows through an environment variable and is validated against a version regex before use — it is never interpolated into a `run:` shell, which prevents script injection in the `id-token: write` publish job.
- All actions are pinned to full commit SHAs (version in a trailing comment; Dependabot bumps them).
- Least-privilege permissions (`contents: read` by default; job adds only `id-token: write`).