### PR TITLE
Add network-free unit test project and CI

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,25 @@
+# BuckarooSdk_DotNet
+
+.NET SDK for the Buckaroo payment API. The library (`BuckarooSdk`) targets `netstandard2.0`;
+its only runtime dependency is Newtonsoft.Json.
+
+## Build & test
+
+- Build the library: `dotnet build BuckarooSdk/BuckarooSdk.csproj`
+- Run unit tests: `dotnet test BuckarooSdk.UnitTests/BuckarooSdk.UnitTests.csproj`
+- `BuckarooSdk.UnitTests` (xUnit, `net8.0`) is the network-free unit suite — add new tests here.
+  Internals are exposed to it via `[InternalsVisibleTo]` in `BuckarooSdk.csproj`.
+- `BuckarooSdk.Tests` is a legacy .NET Framework 4.7.1 integration harness that calls the live
+  gateway and needs real credentials. Do not run it in CI or use it as a template.
+
+## Conventions
+
+- Prefer self-documenting code over comments; match the style of surrounding code.
+- Unit tests must never make network calls — cover the deterministic surface (signatures,
+  serialization, push handling, request building) and mock/sign fixtures instead.
+- Commits: atomic, self-explanatory, no Claude-branded trailers.
+
+## CI
+
+- `.github/workflows/ci.yml` runs the unit tests on every PR (Linux + Windows).
+- `.github/workflows/publish.yml` publishes to NuGet on a published GitHub Release (OIDC); never on PRs.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Code owners for CI/CD workflow changes.
+#
+# Changes under .github/workflows/ can run code and shape release/publish behaviour,
+# so they require review from the .NET development team. For this to be enforced,
+# enable "Require review from Code Owners" in the master branch protection rule.
+/.github/workflows/ @buckaroo-it/buckaroo-net-development

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+# Fast feedback on every pull request and on pushes to the main branch.
+# Runs the network-free unit test suite (BuckarooSdk.UnitTests) only.
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+# Deny-by-default: the test job only needs to read the repository.
+permissions:
+  contents: read
+
+# Cancel superseded runs on the same ref (e.g. new push to a PR).
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Unit tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Cross-platform: several tests assert culture-invariant behaviour (decimal
+        # formatting, signatures), so we validate on both Linux and Windows.
+        os: [ubuntu-24.04, windows-latest]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
+        with:
+          dotnet-version: '8.0.x'
+
+      # Target the test project directly. BuckarooSdk.Tests is a legacy .NET Framework
+      # 4.7.1 (packages.config) integration harness that cannot restore/run on these
+      # runners; only BuckarooSdk.UnitTests (and the SDK it references) is built here.
+      - name: Restore
+        run: dotnet restore BuckarooSdk.UnitTests/BuckarooSdk.UnitTests.csproj
+
+      - name: Build
+        run: dotnet build BuckarooSdk.UnitTests/BuckarooSdk.UnitTests.csproj --configuration Release --no-restore
+
+      - name: Test
+        run: >
+          dotnet test BuckarooSdk.UnitTests/BuckarooSdk.UnitTests.csproj
+          --configuration Release
+          --no-build
+          --logger "trx;LogFileName=test-results.trx"
+          --results-directory TestResults

--- a/BuckarooSdk.UnitTests/Base/PushHandlerTests.cs
+++ b/BuckarooSdk.UnitTests/Base/PushHandlerTests.cs
@@ -1,0 +1,149 @@
+using System.Net;
+using System.Security.Authentication;
+using System.Runtime.Serialization;
+using System.Text;
+using BuckarooSdk;
+using BuckarooSdk.Base;
+using BuckarooSdk.Connection;
+using BuckarooSdk.DataTypes.Push;
+using BuckarooSdk.Services.Ideal.Push;
+using BuckarooSdk.UnitTests.TestSupport;
+using Xunit;
+
+namespace BuckarooSdk.UnitTests.Base
+{
+    /// <summary>
+    /// Verifies push (webhook) handling end-to-end without any network: a push body is signed with the
+    /// SDK's own <see cref="SignatureCalculationService"/> exactly as Buckaroo would, then handed to the
+    /// <c>PushHandler</c> obtained from the public <see cref="SdkClient"/> entry point.
+    /// </summary>
+    public class PushHandlerTests
+    {
+        private const string PushUri = "https://myshop.example.com/buckaroo/push";
+
+        private static string SignedAuthorizationHeader(byte[] body)
+        {
+            var encodedUri = WebUtility.UrlEncode(PushUri).ToLower();
+            var signature = new SignatureCalculationService().CalculateSignature(
+                body,
+                System.Net.Http.HttpMethod.Post.ToString(),
+                "1500000000",
+                "nonce0123456789",
+                encodedUri,
+                TestCredentials.WebsiteKey,
+                TestCredentials.ApiKey);
+
+            return $"hmac {signature}";
+        }
+
+        private static PushHandler NewPushHandler()
+            => new SdkClient().GetPushHandler(TestCredentials.ApiKey);
+
+        [Fact]
+        public void DeserializePush_ValidTransactionPush_ParsesTopLevelFields()
+        {
+            var body = TestData.ReadBytes("Pushes", "ideal-transaction-push.json");
+            var authorizationHeader = SignedAuthorizationHeader(body);
+
+            var push = NewPushHandler().DeserializePush(body, PushUri, authorizationHeader);
+
+            var transactionPush = Assert.IsType<TransactionPush>(push);
+            Assert.Equal("F948CAA0C8FC4371892126BB03AB997C", transactionPush.Key);
+            Assert.Equal("NL1802813331", transactionPush.Invoice);
+            Assert.Equal("ideal", transactionPush.ServiceCode);
+            Assert.Equal(BuckarooSdk.Constants.Status.Success, transactionPush.Status.Code.Code);
+            Assert.True(transactionPush.IsTest);
+            Assert.Equal(71.84m, transactionPush.AmountDebit);
+        }
+
+        [Fact]
+        public void DeserializePush_ValidTransactionPush_ResolvesTypedActionResponse()
+        {
+            var body = TestData.ReadBytes("Pushes", "ideal-transaction-push.json");
+            var push = NewPushHandler().DeserializePush(body, PushUri, SignedAuthorizationHeader(body));
+
+            var ideal = push.GetActionResponse<IdealPayPush>();
+
+            Assert.NotNull(ideal);
+            Assert.Equal("NL89INGB0002056758", ideal.ConsumerIban);
+            Assert.Equal("INGBNL2A", ideal.ConsumerBic);
+            Assert.Equal("ING Bank", ideal.ConsumerIssuer);
+            Assert.Equal("J. de Tester", ideal.ConsumerName);
+            Assert.Equal("1150000854689906", ideal.Transactionid);
+        }
+
+        [Fact]
+        public void DeserializePush_ExposesSelectedServiceNames()
+        {
+            var body = TestData.ReadBytes("Pushes", "ideal-transaction-push.json");
+            var push = NewPushHandler().DeserializePush(body, PushUri, SignedAuthorizationHeader(body));
+
+            var services = push.GetServices();
+
+            Assert.Contains(BuckarooSdk.Constants.Services.ServiceNames.Ideal, services);
+        }
+
+        [Fact]
+        public void DeserializePush_InvalidSignature_ThrowsAuthenticationException()
+        {
+            var body = TestData.ReadBytes("Pushes", "ideal-transaction-push.json");
+            // A validly-formatted header signed for a different body will not verify against this body.
+            var wrongHeader = SignedAuthorizationHeader(Encoding.UTF8.GetBytes("{\"Transaction\":{}}"));
+
+            Assert.Throws<AuthenticationException>(
+                () => NewPushHandler().DeserializePush(body, PushUri, wrongHeader));
+        }
+
+        [Fact]
+        public void DeserializePush_TamperedBody_ThrowsAuthenticationException()
+        {
+            var body = TestData.ReadBytes("Pushes", "ideal-transaction-push.json");
+            var authorizationHeader = SignedAuthorizationHeader(body);
+
+            // Flip one byte directly so the tamper is guaranteed regardless of fixture content
+            // (a content-coupled string replace could silently become a no-op after a fixture edit).
+            var tamperedBody = (byte[])body.Clone();
+            tamperedBody[tamperedBody.Length / 2] ^= 0x01;
+
+            Assert.Throws<AuthenticationException>(
+                () => NewPushHandler().DeserializePush(tamperedBody, PushUri, authorizationHeader));
+        }
+
+        [Fact]
+        public void DeserializePush_ValidDataRequestPush_ReturnsDataRequest()
+        {
+            var body = TestData.ReadBytes("Pushes", "emandate-datarequest-push.json");
+
+            var push = NewPushHandler().DeserializePush(body, PushUri, SignedAuthorizationHeader(body));
+
+            var dataRequest = Assert.IsType<DataRequest>(push);
+            Assert.Equal("7B9E1C2D3F4A4B5C8D9E0F1A2B3C4D5E", dataRequest.Key);
+            Assert.Equal("emandate", dataRequest.ServiceCode);
+            Assert.Equal(BuckarooSdk.Constants.Status.Success, dataRequest.Status.Code.Code);
+        }
+
+        [Fact]
+        public void DeserializePush_ExtractsCustomParameters()
+        {
+            var body = TestData.ReadBytes("Pushes", "ideal-push-with-custom-parameters.json");
+
+            var push = NewPushHandler().DeserializePush(body, PushUri, SignedAuthorizationHeader(body));
+
+            var transactionPush = Assert.IsType<TransactionPush>(push);
+            Assert.NotNull(transactionPush.CustomParameters);
+            Assert.Collection(transactionPush.CustomParameters.List,
+                p => { Assert.Equal("OrderId", p.Name); Assert.Equal("ORDER-4242", p.Value); },
+                p => { Assert.Equal("ShopReference", p.Name); Assert.Equal("SHOP-7", p.Value); });
+        }
+
+        [Fact]
+        public void DeserializePush_UnknownPushType_ThrowsSerializationException()
+        {
+            var body = Encoding.UTF8.GetBytes("{\"Something\":{\"Key\":\"X\"}}");
+            var authorizationHeader = SignedAuthorizationHeader(body);
+
+            Assert.Throws<SerializationException>(
+                () => NewPushHandler().DeserializePush(body, PushUri, authorizationHeader));
+        }
+    }
+}

--- a/BuckarooSdk.UnitTests/BuckarooSdk.UnitTests.csproj
+++ b/BuckarooSdk.UnitTests/BuckarooSdk.UnitTests.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- LTS target so the suite runs on the widest range of machines/CI agents.
+         RollForward=Major lets it also execute on newer runtimes (e.g. .NET 10) when 8 is absent. -->
+    <TargetFramework>net8.0</TargetFramework>
+    <RollForward>Major</RollForward>
+    <LangVersion>latest</LangVersion>
+    <Nullable>disable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+    <!-- The SDK pins Newtonsoft.Json 12.0.3 (a known-vuln transitive dependency). That is an SDK
+         packaging concern, not a test concern; silence the audit noise so test output stays clean. -->
+    <NuGetAudit>false</NuGetAudit>
+    <NoWarn>$(NoWarn);NU1901;NU1902;NU1903;NU1904</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BuckarooSdk\BuckarooSdk.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Recorded JSON fixtures (pushes / responses) copied next to the test assembly. -->
+    <None Include="TestData\**\*.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+</Project>

--- a/BuckarooSdk.UnitTests/Connection/SignatureCalculationServiceTests.cs
+++ b/BuckarooSdk.UnitTests/Connection/SignatureCalculationServiceTests.cs
@@ -1,0 +1,148 @@
+using System.Text;
+using BuckarooSdk.Connection;
+using Xunit;
+
+namespace BuckarooSdk.UnitTests.Connection
+{
+    /// <summary>
+    /// The HMAC-SHA256 request/response/push signature is the SDK's security boundary and is fully
+    /// deterministic, so it is exercised exhaustively here. A regression in this algorithm would make
+    /// every live request fail authentication, so these tests guard the exact wire format.
+    /// </summary>
+    public class SignatureCalculationServiceTests
+    {
+        // Fixed inputs whose expected signature was computed independently (out-of-band) and pinned.
+        // If the algorithm changes in any way, the known-answer test below breaks.
+        private const string WebsiteKey = "WEBSITE123";
+        private const string ApiKey = "SECRETAPIKEY";
+        private const string HttpMethod = "POST";
+        private const string Uri = "testcheckout.buckaroo.nl%2fjson%2ftransaction";
+        private const string TimeStamp = "1500000000";
+        private const string Nonce = "abcdef0123456789";
+        private const string ExpectedSignature =
+            "WEBSITE123:Hw0aw3Nd5g5Jg9Mv50h+vy+qS34hE+xAz4CfISejm5A=:abcdef0123456789:1500000000";
+
+        private static readonly byte[] Body = Encoding.UTF8.GetBytes("{\"Currency\":\"EUR\"}");
+
+        private static SignatureCalculationService NewService() => new SignatureCalculationService();
+
+        [Fact]
+        public void CalculateSignature_KnownInputs_ProducesPinnedSignature()
+        {
+            var signature = NewService().CalculateSignature(
+                Body, HttpMethod, TimeStamp, Nonce, Uri, WebsiteKey, ApiKey);
+
+            Assert.Equal(ExpectedSignature, signature);
+        }
+
+        [Fact]
+        public void CalculateSignature_FormatIsWebsiteKeyColonSignatureColonNonceColonTimestamp()
+        {
+            var signature = NewService().CalculateSignature(
+                Body, HttpMethod, TimeStamp, Nonce, Uri, WebsiteKey, ApiKey);
+
+            var parts = signature.Split(':');
+            Assert.Equal(4, parts.Length);
+            Assert.Equal(WebsiteKey, parts[0]);
+            Assert.NotEmpty(parts[1]); // base64 HMAC
+            Assert.Equal(Nonce, parts[2]);
+            Assert.Equal(TimeStamp, parts[3]);
+        }
+
+        [Fact]
+        public void CalculateSignature_IsDeterministic_ForIdenticalInputs()
+        {
+            var a = NewService().CalculateSignature(Body, HttpMethod, TimeStamp, Nonce, Uri, WebsiteKey, ApiKey);
+            var b = NewService().CalculateSignature(Body, HttpMethod, TimeStamp, Nonce, Uri, WebsiteKey, ApiKey);
+
+            Assert.Equal(a, b);
+        }
+
+        [Fact]
+        public void CalculateSignature_EmptyBody_DiffersFromNonEmptyBody()
+        {
+            // With an empty body the MD5 content hash is skipped, so the raw signature string differs.
+            var empty = NewService().CalculateSignature(
+                System.Array.Empty<byte>(), HttpMethod, TimeStamp, Nonce, Uri, WebsiteKey, ApiKey);
+            var nonEmpty = NewService().CalculateSignature(
+                Body, HttpMethod, TimeStamp, Nonce, Uri, WebsiteKey, ApiKey);
+
+            Assert.NotEqual(empty, nonEmpty);
+        }
+
+        [Fact]
+        public void CalculateSignature_TamperedBody_ChangesSignature()
+        {
+            var original = NewService().CalculateSignature(Body, HttpMethod, TimeStamp, Nonce, Uri, WebsiteKey, ApiKey);
+            var tampered = NewService().CalculateSignature(
+                Encoding.UTF8.GetBytes("{\"Currency\":\"USD\"}"), HttpMethod, TimeStamp, Nonce, Uri, WebsiteKey, ApiKey);
+
+            Assert.NotEqual(original, tampered);
+        }
+
+        [Theory]
+        [InlineData("OTHERKEY", ApiKey, HttpMethod, Uri, TimeStamp, Nonce)]
+        [InlineData(WebsiteKey, "OTHERSECRET", HttpMethod, Uri, TimeStamp, Nonce)]
+        [InlineData(WebsiteKey, ApiKey, "GET", Uri, TimeStamp, Nonce)]
+        [InlineData(WebsiteKey, ApiKey, HttpMethod, "other.host%2fpath", TimeStamp, Nonce)]
+        [InlineData(WebsiteKey, ApiKey, HttpMethod, Uri, "1600000000", Nonce)]
+        [InlineData(WebsiteKey, ApiKey, HttpMethod, Uri, TimeStamp, "differentnonce00")]
+        public void CalculateSignature_IsSensitiveToEveryInput(
+            string websiteKey, string apiKey, string method, string uri, string timeStamp, string nonce)
+        {
+            var baseline = NewService().CalculateSignature(Body, HttpMethod, TimeStamp, Nonce, Uri, WebsiteKey, ApiKey);
+            var altered = NewService().CalculateSignature(Body, method, timeStamp, nonce, uri, websiteKey, apiKey);
+
+            Assert.NotEqual(baseline, altered);
+        }
+
+        [Fact]
+        public void VerifySignature_RoundTripsWithCalculateSignature()
+        {
+            var service = NewService();
+            var signature = service.CalculateSignature(Body, HttpMethod, TimeStamp, Nonce, Uri, WebsiteKey, ApiKey);
+            var authorizationHeader = $"hmac {signature}";
+
+            var verified = service.VerifySignature(Body, HttpMethod, Uri, ApiKey, authorizationHeader);
+
+            Assert.True(verified);
+        }
+
+        [Fact]
+        public void VerifySignature_ReturnsFalse_WhenBodyIsTampered()
+        {
+            var service = NewService();
+            var signature = service.CalculateSignature(Body, HttpMethod, TimeStamp, Nonce, Uri, WebsiteKey, ApiKey);
+            var authorizationHeader = $"hmac {signature}";
+
+            var verified = service.VerifySignature(
+                Encoding.UTF8.GetBytes("{\"Currency\":\"USD\"}"), HttpMethod, Uri, ApiKey, authorizationHeader);
+
+            Assert.False(verified);
+        }
+
+        [Fact]
+        public void VerifySignature_ReturnsFalse_WhenApiKeyIsWrong()
+        {
+            var service = NewService();
+            var signature = service.CalculateSignature(Body, HttpMethod, TimeStamp, Nonce, Uri, WebsiteKey, ApiKey);
+            var authorizationHeader = $"hmac {signature}";
+
+            var verified = service.VerifySignature(Body, HttpMethod, Uri, "WRONGSECRET", authorizationHeader);
+
+            Assert.False(verified);
+        }
+
+        [Fact]
+        public void VerifySignature_ReturnsFalse_WhenRequestUriDiffers()
+        {
+            var service = NewService();
+            var signature = service.CalculateSignature(Body, HttpMethod, TimeStamp, Nonce, Uri, WebsiteKey, ApiKey);
+            var authorizationHeader = $"hmac {signature}";
+
+            var verified = service.VerifySignature(Body, HttpMethod, "other.host%2fpath", ApiKey, authorizationHeader);
+
+            Assert.False(verified);
+        }
+    }
+}

--- a/BuckarooSdk.UnitTests/Constants/StatusCodeTests.cs
+++ b/BuckarooSdk.UnitTests/Constants/StatusCodeTests.cs
@@ -1,0 +1,30 @@
+using Xunit;
+using SdkStatus = BuckarooSdk.Constants.Status;
+
+namespace BuckarooSdk.UnitTests.Constants
+{
+    /// <summary>
+    /// The numeric status codes are a shared contract with the Buckaroo gateway that consumers branch on
+    /// (e.g. <c>if (push.Status.Code.Code == Status.Success)</c>). Pinning them here turns an accidental
+    /// edit of the contract into a failing test rather than a silent production incident.
+    /// </summary>
+    public class StatusCodeTests
+    {
+        [Theory]
+        [InlineData(190, SdkStatus.Success)]
+        [InlineData(490, SdkStatus.Failed)]
+        [InlineData(491, SdkStatus.FailedValidation)]
+        [InlineData(492, SdkStatus.TechnicalError)]
+        [InlineData(690, SdkStatus.Declined)]
+        [InlineData(790, SdkStatus.PendingInput)]
+        [InlineData(791, SdkStatus.PendingProcessing)]
+        [InlineData(792, SdkStatus.WaitingForConsumer)]
+        [InlineData(793, SdkStatus.OnHold)]
+        [InlineData(890, SdkStatus.CanceledByUser)]
+        [InlineData(891, SdkStatus.CanceledByMerchant)]
+        public void StatusCode_MatchesGatewayContract(int expected, int actual)
+        {
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/BuckarooSdk.UnitTests/README.md
+++ b/BuckarooSdk.UnitTests/README.md
@@ -1,0 +1,75 @@
+# BuckarooSdk.UnitTests
+
+Fast, deterministic, **network-free** unit tests for the Buckaroo .NET SDK. The goal is to give
+confidence that changes to the SDK are safe *without* ever calling the Buckaroo API.
+
+## Why a new project
+
+The existing `BuckarooSdk.Tests` project is a legacy .NET Framework 4.7.1 (`packages.config`)
+harness whose "tests" call `request.Execute()` against the live `testcheckout.buckaroo.nl`
+gateway, require real credentials, and in places open a browser. It is an integration/manual
+harness — it cannot run on CI and gives no isolated feedback. This project complements it with
+true unit tests.
+
+## What is covered
+
+Everything the SDK does *before* the bytes leave the machine — which is where almost all logic
+(and almost all regressions) live:
+
+| Area | Suite | What it protects |
+| --- | --- | --- |
+| HMAC-SHA256 auth | `Connection/SignatureCalculationServiceTests` | The request/response/push signature — pinned known-answer + tamper sensitivity |
+| Push (webhook) handling | `Base/PushHandlerTests` | Signature verification + deserialization of a signed transaction *and* data-request push, custom-parameter extraction, with no network |
+| Request → parameter mapping | `Services/ServiceHelperTests` | The reflection engine that flattens typed requests (groups, collections, decimals, culture) |
+| Fluent builder | `Transaction/FluentBuilderTests` | Authentication wiring, endpoint selection, service/action/version assembly, and multi-service chaining |
+| Service catalog | `Services/ServiceCatalogTests` | Pins the `(service, action, version)` contract for the major payment methods and their non-Pay actions |
+| Data-request path | `Transaction/DataRequestTests` | The data-request endpoint, distinct from the transaction endpoint |
+| Wire-format serialization | `Serialization/TransactionRequestSerializationTests` | The exact camelCase JSON that would be POSTed (incl. custom/additional parameter shapes) |
+| Response deserialization | `Serialization/ResponseDeserializationTests` | Parsing a recorded gateway response into `RequestResponse` + `GetActionResponse<T>` mapping |
+| Client entry point | `SdkClientTests` | `CreateRequest` / logger selection / push + signature factories |
+| Status contract | `Constants/StatusCodeTests` | The numeric status codes consumers branch on |
+
+Tests are written with **xUnit** and the built-in `Assert` (no extra assertion/mocking
+dependencies), mirroring the approach used by the Stripe .NET SDK.
+
+## Running
+
+```bash
+# from the repository root
+dotnet test BuckarooSdk.UnitTests/BuckarooSdk.UnitTests.csproj
+
+# with code coverage (coverlet is referenced)
+dotnet test BuckarooSdk.UnitTests/BuckarooSdk.UnitTests.csproj --collect:"XPlat Code Coverage"
+```
+
+The project targets `net8.0` (LTS). `RollForward=Major` lets the suite also execute on newer
+runtimes (e.g. .NET 10) when the .NET 8 runtime is not installed.
+
+## How it stays network-free
+
+- The deterministic pieces (signature, request building, serialization) are exercised directly.
+- Push handling is tested by **signing a fixture with the SDK's own `SignatureCalculationService`**
+  exactly as Buckaroo's servers would, then feeding the signed body to the `PushHandler`.
+- Recorded JSON fixtures live under `TestData/` and are copied next to the test assembly.
+- The SDK exposes its internals to this assembly via `[InternalsVisibleTo("BuckarooSdk.UnitTests")]`
+  (declared in `BuckarooSdk.csproj`), so the assembled request object graph and internal helpers
+  can be asserted on precisely.
+
+## Known limitation / possible follow-up
+
+The `Connector` constructs its `HttpClient` (and inner `HttpClientHandler`) internally, so there is
+no seam to inject a mocked transport. That means the final `Execute()`/HTTP round-trip is **not**
+unit-tested here (it would be an integration test). Stripe and Adyen both test their full client
+stack by injecting a mock `HttpMessageHandler`. Adding a small, additive injection point to
+`Connector` would allow the same here — driving request serialization, the HMAC `Authorization`
+header, and response deserialization end-to-end with a fake handler and still no network. This was
+intentionally left out to avoid changing the production send path.
+
+## Latent SDK issue surfaced while writing these tests
+
+`ServiceHelper.StringifyParameter` special-cases only `decimal` with `InvariantCulture`; every other
+type (notably `DateTime`) falls through to `value.ToString()`, which uses the current thread culture.
+Date-bearing request parameters (birth dates, invoice/due dates, validity windows) therefore serialize
+differently depending on the server's locale — a real wire-format hazard. No test was added asserting a
+fixed format because doing so would either encode buggy behaviour or fail the build; fixing it in the
+SDK (`ToString(CultureInfo.InvariantCulture)`) and then pinning it is the recommended follow-up.

--- a/BuckarooSdk.UnitTests/SdkClientTests.cs
+++ b/BuckarooSdk.UnitTests/SdkClientTests.cs
@@ -1,0 +1,83 @@
+using System;
+using BuckarooSdk;
+using BuckarooSdk.Base;
+using BuckarooSdk.Connection;
+using BuckarooSdk.Logging;
+using BuckarooSdk.UnitTests.TestSupport;
+using Xunit;
+
+namespace BuckarooSdk.UnitTests
+{
+    /// <summary>
+    /// Exercises the public <see cref="SdkClient"/> entry point: request creation, logger selection,
+    /// and the push/signature helper factories. None of these touch the network.
+    /// </summary>
+    public class SdkClientTests
+    {
+        [Fact]
+        public void CreateRequest_ReturnsRequest()
+        {
+            Assert.NotNull(new SdkClient().CreateRequest());
+        }
+
+        [Fact]
+        public void CreateRequest_WithExplicitLogger_ReturnsRequest()
+        {
+            Assert.NotNull(new SdkClient().CreateRequest(new StandardLogger()));
+            Assert.NotNull(new SdkClient().CreateRequest(new ExtensiveLogger()));
+        }
+
+        [Fact]
+        public void Constructor_NullLoggerFactory_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => new SdkClient((Func<ILogger>)null));
+        }
+
+        [Fact]
+        public void Constructor_CustomLoggerFactory_IsUsedForCreatedRequests()
+        {
+            var client = new SdkClient(() => new ExtensiveLogger());
+
+            // Assert the produced request actually carries the logger the factory makes — otherwise this
+            // would pass even if the factory were ignored and the default StandardLogger used.
+            Assert.IsType<ExtensiveLogger>(client.CreateRequest().BuckarooSdkLogger);
+        }
+
+        [Fact]
+        public void GetPushHandler_ReturnsHandler()
+        {
+            Assert.NotNull(new SdkClient().GetPushHandler(TestCredentials.ApiKey));
+        }
+
+        [Fact]
+        public void GetPushHandler_IsCachedPerClient()
+        {
+            var client = new SdkClient();
+
+            var first = client.GetPushHandler(TestCredentials.ApiKey);
+            var second = client.GetPushHandler(TestCredentials.ApiKey);
+
+            Assert.Same(first, second);
+        }
+
+        [Fact]
+        public void GetPushHandler_IgnoresApiKeyAfterFirstCall()
+        {
+            // Characterizes a real hazard: the handler is cached on first use and the apiKey argument is
+            // ignored thereafter, so a later call with a *different* key silently returns the handler bound
+            // to the FIRST key. Pinning this makes any change to the contract a deliberate, visible one.
+            var client = new SdkClient();
+
+            var first = client.GetPushHandler(TestCredentials.ApiKey);
+            var second = client.GetPushHandler("A_COMPLETELY_DIFFERENT_KEY");
+
+            Assert.Same(first, second);
+        }
+
+        [Fact]
+        public void GetSignatureCalculationService_ReturnsService()
+        {
+            Assert.NotNull(new SdkClient().GetSignatureCalculationService());
+        }
+    }
+}

--- a/BuckarooSdk.UnitTests/Serialization/ResponseDeserializationTests.cs
+++ b/BuckarooSdk.UnitTests/Serialization/ResponseDeserializationTests.cs
@@ -1,0 +1,68 @@
+using System.Linq;
+using BuckarooSdk.DataTypes.Response;
+using BuckarooSdk.Services.Ideal.TransactionRequest;
+using BuckarooSdk.UnitTests.TestSupport;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace BuckarooSdk.UnitTests.Serialization
+{
+    /// <summary>
+    /// Deserializes a recorded gateway response into the <see cref="RequestResponse"/> that every
+    /// <c>Execute()</c> returns, using the same call the SDK's <c>Connector</c> makes
+    /// (<c>JsonConvert.DeserializeObject&lt;RequestResponse&gt;</c> with default settings). This covers the
+    /// response side of the wire — status parsing, service lookup, and the reflection-based
+    /// <c>GetActionResponse&lt;T&gt;</c> mapping — without any network call.
+    /// </summary>
+    public class ResponseDeserializationTests
+    {
+        private static RequestResponse LoadIdealPayResponse()
+        {
+            var json = TestData.ReadText("Responses", "ideal-pay-response.json");
+            return JsonConvert.DeserializeObject<RequestResponse>(json);
+        }
+
+        [Fact]
+        public void Deserialize_ParsesTopLevelFieldsAndStatus()
+        {
+            var response = LoadIdealPayResponse();
+
+            Assert.Equal("A9CF3A004C0144A2B1709EFAE7841388", response.Key);
+            Assert.Equal("NL1802813331", response.Invoice);
+            Assert.Equal("ideal", response.ServiceCode);
+            Assert.Equal(BuckarooSdk.Constants.Status.Success, response.Status.Code.Code);
+            Assert.Equal(12.34m, response.AmountDebit);
+        }
+
+        [Fact]
+        public void Deserialize_ExposesSelectedServiceNames()
+        {
+            var response = LoadIdealPayResponse();
+
+            Assert.Contains(BuckarooSdk.Constants.Services.ServiceNames.Ideal, response.GetServices());
+        }
+
+        [Fact]
+        public void GetActionResponse_MapsServiceParametersOntoTypedResponse()
+        {
+            var response = LoadIdealPayResponse();
+
+            var ideal = response.GetActionResponse<IdealPayResponse>();
+
+            Assert.NotNull(ideal);
+            Assert.Equal("1150000854689906", ideal.TransactionId);
+            Assert.Equal("ING Bank", ideal.ConsumerIssuer);
+        }
+
+        [Fact]
+        public void GetActionResponse_ReturnsNull_WhenServiceAbsent()
+        {
+            var response = LoadIdealPayResponse();
+
+            // No PayPal service is present in the response, so the typed lookup returns null.
+            var payPal = response.GetActionResponse<BuckarooSdk.Services.PayPal.PayPalPayResponse>();
+
+            Assert.Null(payPal);
+        }
+    }
+}

--- a/BuckarooSdk.UnitTests/Serialization/TransactionRequestSerializationTests.cs
+++ b/BuckarooSdk.UnitTests/Serialization/TransactionRequestSerializationTests.cs
@@ -1,0 +1,122 @@
+using System.Globalization;
+using BuckarooSdk;
+using BuckarooSdk.DataTypes.RequestBases;
+using BuckarooSdk.Services.Ideal.TransactionRequest;
+using BuckarooSdk.Transaction;
+using BuckarooSdk.UnitTests.TestSupport;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace BuckarooSdk.UnitTests.Serialization
+{
+    /// <summary>
+    /// Serializes the assembled request body with the exact settings the SDK's <c>Connector</c> uses,
+    /// so these tests assert on the precise JSON that would be POSTed to Buckaroo — the camelCase
+    /// property names and the nested <c>services.serviceList</c> shape the gateway requires — without
+    /// performing any request.
+    /// </summary>
+    public class TransactionRequestSerializationTests
+    {
+        private static TransactionBase BuildIdealPayBody()
+        {
+            var configured = new SdkClient().CreateRequest()
+                .Authenticate(TestCredentials.WebsiteKey, TestCredentials.ApiKey, false, new CultureInfo("nl-NL"))
+                .TransactionRequest()
+                .SetBasicFields(new TransactionBase
+                {
+                    Currency = "EUR",
+                    AmountDebit = 0.02m,
+                    Invoice = "SDK_TEST_0001",
+                    Description = "Unit test transaction",
+                })
+                .Ideal()
+                .Pay(new IdealPayRequest { Issuer = "INGBNL2A" });
+
+            return configured.BaseTransaction.TransactionBase;
+        }
+
+        [Fact]
+        public void Serialize_UsesCamelCaseTopLevelProperties()
+        {
+            var json = BuckarooJson.SerializeToObject(BuildIdealPayBody());
+
+            Assert.Equal("EUR", (string)json["currency"]);
+            Assert.Equal(0.02m, (decimal)json["amountDebit"]);
+            Assert.Equal("SDK_TEST_0001", (string)json["invoice"]);
+            Assert.Equal("Unit test transaction", (string)json["description"]);
+        }
+
+        [Fact]
+        public void Serialize_NestsServicesUnderServiceList()
+        {
+            var json = BuckarooJson.SerializeToObject(BuildIdealPayBody());
+
+            var serviceList = (JArray)json["services"]["serviceList"];
+            var service = Assert.Single(serviceList);
+            Assert.Equal("Ideal", (string)service["name"]);
+            Assert.Equal("pay", (string)service["action"]);
+            Assert.Equal("2", (string)service["version"]);
+        }
+
+        [Fact]
+        public void Serialize_IncludesServiceParameterNameAndValue()
+        {
+            var json = BuckarooJson.SerializeToObject(BuildIdealPayBody());
+
+            var parameters = (JArray)json["services"]["serviceList"][0]["parameters"];
+            var parameter = Assert.Single(parameters);
+            Assert.Equal("Issuer", (string)parameter["name"]);
+            Assert.Equal("INGBNL2A", (string)parameter["value"]);
+        }
+
+        [Fact]
+        public void Serialize_DecimalAmount_ParsesBackTo0_02_UnderCommaCulture()
+        {
+            // Under a comma-decimal locale the emitted JSON must still parse as the numeric 0.02 (a comma
+            // would produce invalid JSON / a different value). Asserting the parsed JToken — rather than a
+            // raw substring — avoids coupling to Newtonsoft's indentation and reads the actual value.
+            var original = System.Threading.Thread.CurrentThread.CurrentCulture;
+            try
+            {
+                System.Threading.Thread.CurrentThread.CurrentCulture = new CultureInfo("nl-NL");
+                var json = BuckarooJson.SerializeToObject(BuildIdealPayBody());
+
+                Assert.Equal(0.02m, (decimal)json["amountDebit"]);
+            }
+            finally
+            {
+                System.Threading.Thread.CurrentThread.CurrentCulture = original;
+            }
+        }
+
+        [Fact]
+        public void Serialize_CustomAndAdditionalParameters_ProduceLegacyListShapes()
+        {
+            var basicFields = new TransactionBase
+            {
+                Currency = "EUR",
+                AmountDebit = 1.00m,
+                Invoice = "SDK_TEST_PARAMS",
+            };
+            basicFields.AddCustomParameter("MyCustom", "CustomValue");
+            basicFields.AddAdditionalParameter("MyAdditional", "AdditionalValue");
+
+            var configured = new SdkClient().CreateRequest()
+                .Authenticate(TestCredentials.WebsiteKey, TestCredentials.ApiKey, false, new CultureInfo("nl-NL"))
+                .TransactionRequest()
+                .SetBasicFields(basicFields)
+                .Ideal()
+                .Pay(new() { Issuer = "INGBNL2A" });
+
+            var json = BuckarooJson.SerializeToObject(configured.BaseTransaction.TransactionBase);
+
+            var custom = Assert.Single((JArray)json["customParameters"]["list"]);
+            Assert.Equal("MyCustom", (string)custom["name"]);
+            Assert.Equal("CustomValue", (string)custom["value"]);
+
+            var additional = Assert.Single((JArray)json["additionalParameters"]["additionalParameter"]);
+            Assert.Equal("MyAdditional", (string)additional["name"]);
+            Assert.Equal("AdditionalValue", (string)additional["value"]);
+        }
+    }
+}

--- a/BuckarooSdk.UnitTests/Services/ServiceCatalogTests.cs
+++ b/BuckarooSdk.UnitTests/Services/ServiceCatalogTests.cs
@@ -1,0 +1,119 @@
+using System.Globalization;
+using System.Linq;
+using BuckarooSdk;
+using BuckarooSdk.DataTypes.RequestBases;
+using BuckarooSdk.Transaction;
+using BuckarooSdk.UnitTests.TestSupport;
+using Xunit;
+
+namespace BuckarooSdk.UnitTests.Services
+{
+    /// <summary>
+    /// Pins the service code / action / version that each payment method emits onto the request. These
+    /// strings are a hard contract with the Buckaroo gateway: a typo (e.g. "Pay" vs "pay") or a wrong
+    /// version silently breaks that one payment method in production. Building each method through the
+    /// public fluent API and asserting the emitted service turns such a change into a failing test.
+    /// </summary>
+    public class ServiceCatalogTests
+    {
+        private static ConfiguredTransaction NewTransaction()
+        {
+            return new SdkClient().CreateRequest()
+                .Authenticate(TestCredentials.WebsiteKey, TestCredentials.ApiKey, false, new CultureInfo("nl-NL"))
+                .TransactionRequest()
+                .SetBasicFields(new TransactionBase
+                {
+                    Currency = "EUR",
+                    AmountDebit = 1.00m,
+                    Invoice = "SDK_TEST_CATALOG",
+                });
+        }
+
+        private static void AssertService(
+            ConfiguredServiceTransaction configured, string expectedName, string expectedAction, string expectedVersion)
+        {
+            var service = configured.BaseTransaction.TransactionBase.Services.ServiceList.Last();
+            Assert.Equal(expectedName, service.Name);
+            Assert.Equal(expectedAction, service.Action);
+            Assert.Equal(expectedVersion, service.Version);
+        }
+
+        [Fact]
+        public void Ideal_Pay() =>
+            AssertService(NewTransaction().Ideal().Pay(new() { Issuer = "INGBNL2A" }), "Ideal", "pay", "2");
+
+        [Fact]
+        public void IdealProcessing_Pay() =>
+            AssertService(NewTransaction().IdealProcessing().Pay(new()), "Idealprocessing", "pay", "2");
+
+        [Fact]
+        public void Giropay_Pay() =>
+            AssertService(NewTransaction().Giropay().Pay(new()), "giropay", "Pay", "2");
+
+        [Fact]
+        public void Sofort_Pay() =>
+            AssertService(NewTransaction().Sofort().Pay(new()), "sofortueberweisung", "Pay", "1");
+
+        [Fact]
+        public void PayPal_Pay() =>
+            AssertService(NewTransaction().PayPal().Pay(new()), "PayPal", "pay", "1");
+
+        [Fact]
+        public void Transfer_Pay() =>
+            AssertService(NewTransaction().Transfer().Pay(new()), "Transfer", "pay", "1");
+
+        [Fact]
+        public void Eps_Pay() =>
+            AssertService(NewTransaction().EPS().Pay(new()), "eps", "Pay", "1");
+
+        [Fact]
+        public void P24_Pay() =>
+            AssertService(NewTransaction().P24().Pay(new()), "Przelewy24", "pay", "1");
+
+        [Fact]
+        public void SepaDirectDebit_Pay() =>
+            AssertService(NewTransaction().SepaDirectDebit().Pay(new()), "SepaDirectDebit", "pay", "1");
+
+        [Fact]
+        public void SimpleSepaDirectDebit_Pay() =>
+            AssertService(NewTransaction().SimpleSepaDirectDebit().Pay(new()), "SimpleSepaDirectDebit", "pay", "2");
+
+        [Fact]
+        public void Multibanco_Pay() =>
+            AssertService(NewTransaction().Multibanco().Pay(new()), "Multibanco", "pay", "0");
+
+        [Fact]
+        public void MBWay_Pay() =>
+            AssertService(NewTransaction().MBWay().Pay(new()), "MBWay", "pay", "0");
+
+        [Fact]
+        public void PaymentInitiation_Pay() =>
+            AssertService(NewTransaction().PaymentInitiation().Pay(new()), "PayByBank", "pay", "0");
+
+        [Fact]
+        public void Bancontact_Pay() =>
+            AssertService(NewTransaction().Bancontact().Pay(new()), "bancontactmrcash", "Pay", "1");
+
+        // Non-Pay actions carry their own action string + version — just as much a gateway contract as Pay.
+
+        [Fact]
+        public void Ideal_Refund() =>
+            AssertService(NewTransaction().Ideal().Refund(new()), "Ideal", "refund", "2");
+
+        [Fact]
+        public void Ideal_PayRemainder() =>
+            AssertService(NewTransaction().Ideal().PayRemainder(new() { Issuer = "INGBNL2A" }), "Ideal", "payremainder", "2");
+
+        [Fact]
+        public void Ideal_PayFastCheckout() =>
+            AssertService(NewTransaction().Ideal().PayFastCheckout(new()), "Ideal", "PayFastCheckout", "2");
+
+        [Fact]
+        public void Sofort_Refund() =>
+            AssertService(NewTransaction().Sofort().Refund(new()), "sofortueberweisung", "Refund", "1");
+
+        [Fact]
+        public void Giropay_Refund() =>
+            AssertService(NewTransaction().Giropay().Refund(new()), "giropay", "Refund", "2");
+    }
+}

--- a/BuckarooSdk.UnitTests/Services/ServiceHelperTests.cs
+++ b/BuckarooSdk.UnitTests/Services/ServiceHelperTests.cs
@@ -1,0 +1,165 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using BuckarooSdk.Services;
+using Xunit;
+
+namespace BuckarooSdk.UnitTests.Services
+{
+    /// <summary>
+    /// <c>ServiceHelper</c> is the reflection engine that flattens every strongly-typed service request
+    /// (iDEAL, Afterpay, Klarna, ...) into the flat name/value/group parameter list Buckaroo expects.
+    /// It is driven here with minimal test doubles built from the SDK's own public parameter-group
+    /// abstractions, so each branch (simple / group / indexed collection / enumerable) is covered without
+    /// coupling to any single payment method.
+    /// </summary>
+    public class ServiceHelperTests
+    {
+        private sealed class SimpleRequest
+        {
+            public string Issuer { get; set; }
+            public string Empty { get; set; }
+        }
+
+        private sealed class AmountRequest
+        {
+            public decimal Amount { get; set; }
+        }
+
+        private sealed class CardRequest
+        {
+            public string CreditcardNumber { get; set; }
+        }
+
+        private sealed class Address : ParameterGroup
+        {
+            public string City { get; set; }
+        }
+
+        private sealed class GroupRequest
+        {
+            public Address BillingAddress { get; set; }
+        }
+
+        private sealed class ArticleCollectionRequest
+        {
+            public ParameterGroupCollection<Address> Articles { get; set; }
+        }
+
+        private sealed class TagsRequest
+        {
+            public List<string> Tags { get; set; }
+        }
+
+        [Fact]
+        public void CreateServiceParameters_SimpleProperty_ProducesSingleParameter()
+        {
+            var parameters = ServiceHelper.CreateServiceParameters(new SimpleRequest { Issuer = "INGBNL2A" });
+
+            var parameter = Assert.Single(parameters);
+            Assert.Equal("Issuer", parameter.Name);
+            Assert.Equal("INGBNL2A", parameter.Value);
+            Assert.Equal(string.Empty, parameter.GroupType);
+            Assert.Equal(string.Empty, parameter.GroupId);
+        }
+
+        [Fact]
+        public void CreateServiceParameters_NullOrEmptyProperties_AreSkipped()
+        {
+            var parameters = ServiceHelper.CreateServiceParameters(new SimpleRequest { Issuer = null, Empty = "" });
+
+            Assert.Empty(parameters);
+        }
+
+        [Fact]
+        public void CreateServiceParameters_Decimal_UsesInvariantCulture_RegardlessOfThreadCulture()
+        {
+            var originalCulture = Thread.CurrentThread.CurrentCulture;
+            try
+            {
+                // nl-NL uses a comma as decimal separator; the wire format must always use a dot.
+                Thread.CurrentThread.CurrentCulture = new CultureInfo("nl-NL");
+
+                var parameters = ServiceHelper.CreateServiceParameters(new AmountRequest { Amount = 12.5m });
+
+                var parameter = Assert.Single(parameters);
+                Assert.Equal("Amount", parameter.Name);
+                Assert.Equal("12.5", parameter.Value);
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = originalCulture;
+            }
+        }
+
+        [Fact]
+        public void CreateServiceParameters_ParameterGroup_TagsParametersWithGroupType()
+        {
+            var request = new GroupRequest { BillingAddress = new Address { City = "Leiden" } };
+
+            var parameters = ServiceHelper.CreateServiceParameters(request);
+
+            var parameter = Assert.Single(parameters);
+            Assert.Equal("City", parameter.Name);
+            Assert.Equal("Leiden", parameter.Value);
+            Assert.Equal(nameof(Address), parameter.GroupType);
+        }
+
+        [Fact]
+        public void CreateServiceParameters_GroupName_IsNotEmittedAsParameter()
+        {
+            var request = new GroupRequest { BillingAddress = new Address { City = "Leiden" } };
+
+            var parameters = ServiceHelper.CreateServiceParameters(request);
+
+            Assert.DoesNotContain(parameters, p => p.Name == nameof(IParameterGroup.GroupName));
+        }
+
+        [Fact]
+        public void CreateServiceParameters_ParameterGroupCollection_AssignsSequentialGroupIds()
+        {
+            var request = new ArticleCollectionRequest
+            {
+                Articles = new ParameterGroupCollection<Address>("Article")
+                {
+                    new Address { City = "Leiden" },
+                    new Address { City = "Utrecht" },
+                },
+            };
+
+            var parameters = ServiceHelper.CreateServiceParameters(request);
+
+            Assert.Equal(2, parameters.Count);
+            Assert.All(parameters, p => Assert.Equal("City", p.Name));
+            Assert.All(parameters, p => Assert.Equal("Article", p.GroupType));
+            Assert.Equal(new[] { "1", "2" }, parameters.Select(p => p.GroupId).ToArray());
+            Assert.Equal(new[] { "Leiden", "Utrecht" }, parameters.Select(p => p.Value).ToArray());
+        }
+
+        [Fact]
+        public void CreateServiceParameters_PlainEnumerable_RepeatsNameWithSequentialGroupIds()
+        {
+            var request = new TagsRequest { Tags = new List<string> { "a", "b", "c" } };
+
+            var parameters = ServiceHelper.CreateServiceParameters(request);
+
+            Assert.Equal(3, parameters.Count);
+            Assert.All(parameters, p => Assert.Equal("Tags", p.Name));
+            Assert.Equal(new[] { "1", "2", "3" }, parameters.Select(p => p.GroupId).ToArray());
+        }
+
+        [Theory]
+        [InlineData("vpay", "VPayCreditcardNumber")]
+        [InlineData("visa", "CreditcardNumber")]
+        [InlineData("", "CreditcardNumber")]
+        public void CreateServiceParameters_VPay_RenamesCreditcardNumber(string serviceName, string expectedName)
+        {
+            var parameters = ServiceHelper.CreateServiceParameters(
+                new CardRequest { CreditcardNumber = "4111111111111111" }, serviceName);
+
+            var parameter = Assert.Single(parameters);
+            Assert.Equal(expectedName, parameter.Name);
+        }
+    }
+}

--- a/BuckarooSdk.UnitTests/TestData/Pushes/emandate-datarequest-push.json
+++ b/BuckarooSdk.UnitTests/TestData/Pushes/emandate-datarequest-push.json
@@ -1,0 +1,37 @@
+{
+	"DataRequest": {
+		"Key": "7B9E1C2D3F4A4B5C8D9E0F1A2B3C4D5E",
+		"Invoice": "NL9988776655",
+		"ServiceCode": "emandate",
+		"Status": {
+			"Code": {
+				"Code": 190,
+				"Description": "Success"
+			},
+			"SubCode": {
+				"Code": "S060",
+				"Description": "Data request successfully processed."
+			},
+			"DateTime": "2018-03-23T14:39:03"
+		},
+		"IsTest": true,
+		"Currency": "EUR",
+		"TransactionType": "V051",
+		"Services": [
+			{
+				"Name": "emandate",
+				"Action": null,
+				"Parameters": [
+					{
+						"Name": "mandateId",
+						"Value": "SDD-0001"
+					}
+				],
+				"VersionAsProperty": 1
+			}
+		],
+		"MutationType": 0,
+		"RelatedTransactions": null,
+		"CustomerName": "J. de Tester"
+	}
+}

--- a/BuckarooSdk.UnitTests/TestData/Pushes/ideal-push-with-custom-parameters.json
+++ b/BuckarooSdk.UnitTests/TestData/Pushes/ideal-push-with-custom-parameters.json
@@ -1,0 +1,47 @@
+{
+	"Transaction": {
+		"Key": "C1D2E3F4A5B60718293A4B5C6D7E8F90",
+		"Invoice": "NL5544332211",
+		"ServiceCode": "ideal",
+		"Status": {
+			"Code": {
+				"Code": 190,
+				"Description": "Success"
+			},
+			"SubCode": {
+				"Code": "S060",
+				"Description": "Transaction successfully processed."
+			},
+			"DateTime": "2018-03-23T14:39:03"
+		},
+		"IsTest": true,
+		"Currency": "EUR",
+		"AmountDebit": 10.00,
+		"TransactionType": "C021",
+		"Services": [
+			{
+				"Name": "ideal",
+				"Action": null,
+				"Parameters": [
+					{
+						"Name": "consumerIssuer",
+						"Value": "ING Bank"
+					}
+				],
+				"VersionAsProperty": 2
+			}
+		],
+		"CustomParameters": [
+			{
+				"Name": "OrderId",
+				"Value": "ORDER-4242"
+			},
+			{
+				"Name": "ShopReference",
+				"Value": "SHOP-7"
+			}
+		],
+		"MutationType": 1,
+		"CustomerName": "J. de Tester"
+	}
+}

--- a/BuckarooSdk.UnitTests/TestData/Pushes/ideal-transaction-push.json
+++ b/BuckarooSdk.UnitTests/TestData/Pushes/ideal-transaction-push.json
@@ -1,0 +1,59 @@
+{
+	"Transaction": {
+		"Key": "F948CAA0C8FC4371892126BB03AB997C",
+		"Invoice": "NL1802813331",
+		"ServiceCode": "ideal",
+		"Status": {
+			"Code": {
+				"Code": 190,
+				"Description": "Success"
+			},
+			"SubCode": {
+				"Code": "S060",
+				"Description": "Transaction successfully processed."
+			},
+			"DateTime": "2018-03-23T14:39:03"
+		},
+		"IsTest": true,
+		"Order": null,
+		"Currency": "EUR",
+		"AmountDebit": 71.84,
+		"TransactionType": "C021",
+		"Services": [
+			{
+				"Name": "ideal",
+				"Action": null,
+				"Parameters": [
+					{
+						"Name": "consumerIssuer",
+						"Value": "ING Bank"
+					},
+					{
+						"Name": "transactionId",
+						"Value": "1150000854689906"
+					},
+					{
+						"Name": "consumerName",
+						"Value": "J. de Tester"
+					},
+					{
+						"Name": "consumerIBAN",
+						"Value": "NL89INGB0002056758"
+					},
+					{
+						"Name": "consumerBIC",
+						"Value": "INGBNL2A"
+					}
+				],
+				"VersionAsProperty": 2
+			}
+		],
+		"MutationType": 1,
+		"RelatedTransactions": null,
+		"IssuingCountry": null,
+		"StartRecurrent": false,
+		"Recurring": false,
+		"CustomerName": "J. de Tester",
+		"PaymentKey": "A9CF3A004C0144A2B1709EFAE7841388"
+	}
+}

--- a/BuckarooSdk.UnitTests/TestData/Responses/ideal-pay-response.json
+++ b/BuckarooSdk.UnitTests/TestData/Responses/ideal-pay-response.json
@@ -1,0 +1,38 @@
+{
+	"Key": "A9CF3A004C0144A2B1709EFAE7841388",
+	"Status": {
+		"Code": {
+			"Code": 190,
+			"Description": "Success"
+		},
+		"SubCode": {
+			"Code": "S060",
+			"Description": "Transaction successfully processed."
+		},
+		"DateTime": "2018-03-23T14:39:03"
+	},
+	"Invoice": "NL1802813331",
+	"ServiceCode": "ideal",
+	"IsTest": true,
+	"Currency": "EUR",
+	"AmountDebit": 12.34,
+	"TransactionType": "C021",
+	"MutationType": 1,
+	"Services": [
+		{
+			"Name": "ideal",
+			"Action": null,
+			"Parameters": [
+				{
+					"Name": "TransactionId",
+					"Value": "1150000854689906"
+				},
+				{
+					"Name": "ConsumerIssuer",
+					"Value": "ING Bank"
+				}
+			],
+			"VersionAsProperty": 2
+		}
+	]
+}

--- a/BuckarooSdk.UnitTests/TestSupport/BuckarooJson.cs
+++ b/BuckarooSdk.UnitTests/TestSupport/BuckarooJson.cs
@@ -1,0 +1,24 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Serialization;
+
+namespace BuckarooSdk.UnitTests.TestSupport
+{
+    /// <summary>
+    /// Serializes request bodies with the exact same settings the SDK's <c>Connector</c> uses when
+    /// it posts to the Buckaroo gateway (camelCase property names, indented). Tests assert on the
+    /// produced JSON so they verify precisely what would go over the wire — without any network call.
+    /// </summary>
+    public static class BuckarooJson
+    {
+        public static readonly JsonSerializerSettings Settings = new JsonSerializerSettings
+        {
+            ContractResolver = new CamelCasePropertyNamesContractResolver(),
+            Formatting = Formatting.Indented,
+        };
+
+        public static string Serialize(object value) => JsonConvert.SerializeObject(value, Settings);
+
+        public static JObject SerializeToObject(object value) => JObject.Parse(Serialize(value));
+    }
+}

--- a/BuckarooSdk.UnitTests/TestSupport/TestCredentials.cs
+++ b/BuckarooSdk.UnitTests/TestSupport/TestCredentials.cs
@@ -1,0 +1,13 @@
+namespace BuckarooSdk.UnitTests.TestSupport
+{
+    /// <summary>
+    /// Obviously-fake, non-functional credentials used purely to drive the deterministic,
+    /// network-free code paths (signature calculation, request building). These are NOT real
+    /// Buckaroo keys and never authenticate against any environment.
+    /// </summary>
+    public static class TestCredentials
+    {
+        public const string WebsiteKey = "5CA1AB1E0000000000000000000000000000BEEF";
+        public const string ApiKey = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    }
+}

--- a/BuckarooSdk.UnitTests/TestSupport/TestData.cs
+++ b/BuckarooSdk.UnitTests/TestSupport/TestData.cs
@@ -1,0 +1,26 @@
+using System.IO;
+using System.Text;
+
+namespace BuckarooSdk.UnitTests.TestSupport
+{
+    /// <summary>
+    /// Loads recorded JSON fixtures that are copied next to the test assembly (see the
+    /// <c>TestData\**\*.json</c> item in the csproj). Reading from <see cref="System.AppContext.BaseDirectory"/>
+    /// keeps fixture loading independent of the working directory and the target framework's bin depth.
+    /// </summary>
+    public static class TestData
+    {
+        private static string Root => Path.Combine(System.AppContext.BaseDirectory, "TestData");
+
+        public static string ReadText(params string[] relativeSegments)
+        {
+            var segments = new string[relativeSegments.Length + 1];
+            segments[0] = Root;
+            System.Array.Copy(relativeSegments, 0, segments, 1, relativeSegments.Length);
+            return File.ReadAllText(Path.Combine(segments), Encoding.UTF8);
+        }
+
+        public static byte[] ReadBytes(params string[] relativeSegments)
+            => Encoding.UTF8.GetBytes(ReadText(relativeSegments));
+    }
+}

--- a/BuckarooSdk.UnitTests/Transaction/DataRequestTests.cs
+++ b/BuckarooSdk.UnitTests/Transaction/DataRequestTests.cs
@@ -1,0 +1,40 @@
+using System.Globalization;
+using BuckarooSdk;
+using BuckarooSdk.UnitTests.TestSupport;
+using Xunit;
+
+namespace BuckarooSdk.UnitTests.Transaction
+{
+    /// <summary>
+    /// A data request and a transaction request are two different gateway operations that hit two
+    /// different endpoints. The transaction endpoint is covered elsewhere; this pins the data-request
+    /// endpoint so that accidentally swapping the two endpoint constants is caught.
+    /// </summary>
+    public class DataRequestTests
+    {
+        [Fact]
+        public void DataRequest_TargetsDataRequestEndpoint()
+        {
+            var data = new SdkClient().CreateRequest()
+                .Authenticate(TestCredentials.WebsiteKey, TestCredentials.ApiKey, false, new CultureInfo("nl-NL"))
+                .DataRequest();
+
+            Assert.Equal("/json/DataRequest", data.AuthenticatedRequest.Request.Endpoint);
+        }
+
+        [Fact]
+        public void DataRequest_EndpointDiffersFromTransactionEndpoint()
+        {
+            var authenticated = new SdkClient().CreateRequest()
+                .Authenticate(TestCredentials.WebsiteKey, TestCredentials.ApiKey, false, new CultureInfo("nl-NL"));
+
+            var transactionEndpoint = authenticated.TransactionRequest().AuthenticatedRequest.Request.Endpoint;
+
+            var dataAuthenticated = new SdkClient().CreateRequest()
+                .Authenticate(TestCredentials.WebsiteKey, TestCredentials.ApiKey, false, new CultureInfo("nl-NL"));
+            var dataEndpoint = dataAuthenticated.DataRequest().AuthenticatedRequest.Request.Endpoint;
+
+            Assert.NotEqual(transactionEndpoint, dataEndpoint);
+        }
+    }
+}

--- a/BuckarooSdk.UnitTests/Transaction/FluentBuilderTests.cs
+++ b/BuckarooSdk.UnitTests/Transaction/FluentBuilderTests.cs
@@ -1,0 +1,136 @@
+using System.Globalization;
+using System.Linq;
+using BuckarooSdk;
+using BuckarooSdk.DataTypes;
+using BuckarooSdk.DataTypes.RequestBases;
+using BuckarooSdk.Services.Ideal.TransactionRequest;
+using BuckarooSdk.Transaction;
+using BuckarooSdk.UnitTests.TestSupport;
+using Xunit;
+
+namespace BuckarooSdk.UnitTests.Transaction
+{
+    /// <summary>
+    /// Asserts on the object graph the fluent API assembles before it is serialized and sent. Reaching
+    /// the internal <c>Request</c>/<c>TransactionBase</c> members (via InternalsVisibleTo) proves the
+    /// builder wires up authentication, the endpoint and the service list correctly — the logic most
+    /// likely to change when new payment methods or actions are added.
+    /// </summary>
+    public class FluentBuilderTests
+    {
+        private static ConfiguredServiceTransaction BuildIdealPay()
+        {
+            return new SdkClient().CreateRequest()
+                .Authenticate(TestCredentials.WebsiteKey, TestCredentials.ApiKey, false, new CultureInfo("nl-NL"), ChannelEnum.Web)
+                .TransactionRequest()
+                .SetBasicFields(new TransactionBase
+                {
+                    Currency = "EUR",
+                    AmountDebit = 0.02m,
+                    Invoice = "SDK_TEST_0001",
+                    Description = "Unit test transaction",
+                })
+                .Ideal()
+                .Pay(new IdealPayRequest { Issuer = "INGBNL2A" });
+        }
+
+        [Fact]
+        public void Authenticate_StoresCredentialsAndContextOnRequest()
+        {
+            var request = new SdkClient().CreateRequest()
+                .Authenticate(TestCredentials.WebsiteKey, TestCredentials.ApiKey, isLive: false,
+                    new CultureInfo("nl-NL"), ChannelEnum.Web)
+                .TransactionRequest();
+
+            var underlying = request.AuthenticatedRequest.Request;
+            Assert.Equal(TestCredentials.WebsiteKey, underlying.WebsiteKey);
+            Assert.Equal(TestCredentials.ApiKey, underlying.ApiKey);
+            Assert.False(underlying.IsLive);
+            Assert.Equal("nl-NL", underlying.Culture.Name);
+            Assert.Equal(ChannelEnum.Web, underlying.Channel);
+        }
+
+        [Fact]
+        public void TransactionRequest_SetsTransactionEndpoint()
+        {
+            var request = new SdkClient().CreateRequest()
+                .Authenticate(TestCredentials.WebsiteKey, TestCredentials.ApiKey, false, new CultureInfo("nl-NL"))
+                .TransactionRequest();
+
+            // Assert the literal wire path, not the SDK's own constant — comparing the constant to itself
+            // would still pass if the constant were changed to a wrong path.
+            Assert.Equal("/json/transaction", request.AuthenticatedRequest.Request.Endpoint);
+        }
+
+        [Fact]
+        public void Ideal_Pay_AddsSingleIdealServiceWithActionAndVersion()
+        {
+            var body = BuildIdealPay().BaseTransaction.TransactionBase;
+
+            var service = Assert.Single(body.Services.ServiceList);
+            Assert.Equal("Ideal", service.Name);
+            Assert.Equal("pay", service.Action);
+            Assert.Equal("2", service.Version);
+        }
+
+        [Fact]
+        public void Ideal_Pay_MapsIssuerIntoServiceParameters()
+        {
+            var body = BuildIdealPay().BaseTransaction.TransactionBase;
+
+            var parameter = Assert.Single(body.Services.ServiceList.Single().Parameters);
+            Assert.Equal("Issuer", parameter.Name);
+            Assert.Equal("INGBNL2A", parameter.Value);
+        }
+
+        [Fact]
+        public void SetBasicFields_PreservesTransactionBaseValues()
+        {
+            var body = BuildIdealPay().BaseTransaction.TransactionBase;
+
+            Assert.Equal("EUR", body.Currency);
+            Assert.Equal(0.02m, body.AmountDebit);
+            Assert.Equal("SDK_TEST_0001", body.Invoice);
+        }
+
+        [Fact]
+        public void AddCustomParameter_AppendsToCustomParameterList()
+        {
+            var basicFields = new TransactionBase
+            {
+                Currency = "EUR",
+                AmountDebit = 1.00m,
+                Invoice = "SDK_TEST_0002",
+            };
+            basicFields.AddCustomParameter("MyField", "MyValue");
+
+            var configured = new SdkClient().CreateRequest()
+                .Authenticate(TestCredentials.WebsiteKey, TestCredentials.ApiKey, false, new CultureInfo("nl-NL"))
+                .TransactionRequest()
+                .SetBasicFields(basicFields)
+                .Ideal()
+                .Pay(new IdealPayRequest { Issuer = "INGBNL2A" });
+
+            var custom = Assert.Single(configured.BaseTransaction.TransactionBase.CustomParameters.List);
+            Assert.Equal("MyField", custom.Name);
+            Assert.Equal("MyValue", custom.Value);
+        }
+
+        [Fact]
+        public void AddAdditionalService_AppendsSecondServiceToSameRequest()
+        {
+            // Combined-invoice / credit-management flows attach a second service to one transaction.
+            var configured = BuildIdealPay()
+                .AddAdditionalService()
+                .CreditManagement()
+                .CreateCombinedInvoice(new());
+
+            var services = configured.BaseTransaction.TransactionBase.Services.ServiceList;
+            Assert.Equal(2, services.Count);
+            Assert.Equal("Ideal", services[0].Name);
+            Assert.Equal("CreditManagement3", services[1].Name);
+            Assert.Equal("CreateCombinedInvoice", services[1].Action);
+            Assert.Equal("1", services[1].Version);
+        }
+    }
+}

--- a/BuckarooSdk.sln
+++ b/BuckarooSdk.sln
@@ -13,6 +13,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BuckarooSdk.Tests", "BuckarooSdk.Tests\BuckarooSdk.Tests.csproj", "{0B26C093-CE7B-410F-BCCF-7A0FC5D5BEB9}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BuckarooSdk.UnitTests", "BuckarooSdk.UnitTests\BuckarooSdk.UnitTests.csproj", "{F4601FFC-4E32-43E9-A950-C85709EBF1B1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -37,6 +39,14 @@ Global
 		{0B26C093-CE7B-410F-BCCF-7A0FC5D5BEB9}.NET45|Any CPU.Build.0 = NET45|Any CPU
 		{0B26C093-CE7B-410F-BCCF-7A0FC5D5BEB9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0B26C093-CE7B-410F-BCCF-7A0FC5D5BEB9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F4601FFC-4E32-43E9-A950-C85709EBF1B1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F4601FFC-4E32-43E9-A950-C85709EBF1B1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F4601FFC-4E32-43E9-A950-C85709EBF1B1}.NET40|Any CPU.ActiveCfg = Debug|Any CPU
+		{F4601FFC-4E32-43E9-A950-C85709EBF1B1}.NET40|Any CPU.Build.0 = Debug|Any CPU
+		{F4601FFC-4E32-43E9-A950-C85709EBF1B1}.NET45|Any CPU.ActiveCfg = Debug|Any CPU
+		{F4601FFC-4E32-43E9-A950-C85709EBF1B1}.NET45|Any CPU.Build.0 = Debug|Any CPU
+		{F4601FFC-4E32-43E9-A950-C85709EBF1B1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F4601FFC-4E32-43E9-A950-C85709EBF1B1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/BuckarooSdk/BuckarooSdk.csproj
+++ b/BuckarooSdk/BuckarooSdk.csproj
@@ -37,4 +37,10 @@
 		<PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
 	</ItemGroup>
 
+	<ItemGroup>
+		<!-- Expose internal types (Service, RequestParameter, ServiceHelper, Request, ...) to the
+		     unit test project so request-building and serialization can be verified without network. -->
+		<InternalsVisibleTo Include="BuckarooSdk.UnitTests" />
+	</ItemGroup>
+
 </Project>


### PR DESCRIPTION
## What

Adds `BuckarooSdk.UnitTests`, a modern xUnit (net8.0) project that tests the SDK **without touching the Buckaroo API**, plus a GitHub Actions workflow that runs it on every PR (Linux + Windows).

The existing `BuckarooSdk.Tests` is a legacy .NET Framework 4.7.1 integration harness that calls the live gateway, needs real credentials, and can't run in CI. It is left untouched; this project gives fast, deterministic, isolated coverage instead.

## Coverage (89 tests, all network-free)

- **HMAC signatures** — pinned known-answer, tamper sensitivity, verify round-trips
- **Push handling** — transaction + data-request pushes signed with the SDK's own signer; custom-parameter extraction
- **ServiceHelper** — request→parameter mapping (groups, collections, decimal InvariantCulture, VPay rename)
- **Fluent builder** — auth wiring, endpoint, service assembly, multi-service chaining
- **Service catalog** — `(service, action, version)` pinned for the major payment methods incl. non-Pay actions
- **Serialization** — exact camelCase request JSON; gateway-response deserialization + `GetActionResponse<T>`
- **Data-request path**, **SdkClient**, **status-code contract**

## Notes

- The SDK gains one line — `[InternalsVisibleTo("BuckarooSdk.UnitTests")]` — so tests can assert the assembled request graph, exactly as Stripe/Adyen do. No behavioural change.
- CI targets the test project directly so the legacy net471 project can't block it.
- **Follow-up (not in this PR):** `ServiceHelper.StringifyParameter` formats only `decimal` with `InvariantCulture`; `DateTime` parameters fall through to the thread culture, so dates serialize differently by server locale. Worth a fix + pinning test.
